### PR TITLE
fix dashboards

### DIFF
--- a/src/grafana_dashboards/sre mock 6 panels - rates.json.tmpl
+++ b/src/grafana_dashboards/sre mock 6 panels - rates.json.tmpl
@@ -95,7 +95,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "rate(avalanche_metric_mmmmm_0_0{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "",
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "rate(avalanche_metric_mmmmm_0_1{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "",
@@ -260,7 +260,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "rate(avalanche_metric_mmmmm_0_2{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "",
@@ -342,7 +342,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "rate(avalanche_metric_mmmmm_0_3{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "",
@@ -424,7 +424,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "rate(avalanche_metric_mmmmm_0_4{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "",
@@ -506,7 +506,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "rate(avalanche_metric_mmmmm_0_5{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "",

--- a/src/grafana_dashboards/sre mock 6 panels - rates.json.tmpl
+++ b/src/grafana_dashboards/sre mock 6 panels - rates.json.tmpl
@@ -674,7 +674,7 @@
         "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": "instance",
         "multi": true,
         "name": "instance_filter",

--- a/src/grafana_dashboards/sre mock 6 panels.json.tmpl
+++ b/src/grafana_dashboards/sre mock 6 panels.json.tmpl
@@ -674,7 +674,7 @@
         "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": "instance",
         "multi": true,
         "name": "instance_filter",

--- a/src/grafana_dashboards/sre mock 6 panels.json.tmpl
+++ b/src/grafana_dashboards/sre mock 6 panels.json.tmpl
@@ -95,7 +95,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_0{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_1{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",
@@ -260,7 +260,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_2{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",
@@ -342,7 +342,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_3{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",
@@ -424,7 +424,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_4{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",
@@ -506,7 +506,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_5{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",

--- a/src/grafana_dashboards/sre_mock_2_panels.json.tmpl
+++ b/src/grafana_dashboards/sre_mock_2_panels.json.tmpl
@@ -219,7 +219,7 @@
         "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": "instance",
         "multi": true,
         "name": "instance_filter",

--- a/src/grafana_dashboards/sre_mock_2_panels.json.tmpl
+++ b/src/grafana_dashboards/sre_mock_2_panels.json.tmpl
@@ -96,7 +96,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_1{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",
@@ -178,7 +178,7 @@
       },
       "targets": [
         {
-          "exemplar": true,
+          "exemplar": false,
           "expr": "avalanche_metric_mmmmm_0_0{series_id=~\"${series_filter}\", instance=~\"${instance_filter}\"}",
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
This PR:
- sets `exemplar` to `false`, otherwise panels show nothing.
- sets `includeAll` to `false` so when opened for the first time there would be only one curve per panel drawn, instead of everything. This makes the load test simpler.