### PR TITLE
Add another 'always firing' rule, that is based on a numeric value

### DIFF
--- a/src/prometheus_alert_rules/always_firing_absent.rule
+++ b/src/prometheus_alert_rules/always_firing_absent.rule
@@ -1,4 +1,4 @@
-alert: AlwaysFiring
+alert: AlwaysFiringDueToAbsentMetric
 expr: absent(some_metric_name_that_shouldnt_exist{job="non_existing_job"})
 for: 0m
 labels:

--- a/src/prometheus_alert_rules/always_firing_numeric.rule
+++ b/src/prometheus_alert_rules/always_firing_numeric.rule
@@ -1,0 +1,8 @@
+alert: AlwaysFiringDueToNumericValue
+expr: avalanche_metric_mmmmm_0_0{series_id="0"} > -1
+for: 0m
+labels:
+  severity: High
+annotations:
+  summary: "Instance {{ $labels.instance }} dummy alarm (always firing)"
+  description: "{{ $labels.instance }} of job {{ $labels.job }} is firing the dummy alarm."


### PR DESCRIPTION
Before this PR, the (only) "always firing" rules was based on the "absent" function.
When this alert fires, it only fires once per app (not per unit), and `{{ $labels.instance }}` is an empty string.

Now adding another "always firing" rule that is based on metric value.