### PR TITLE
Fix rel name and job name

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_remote_write.py
@@ -32,13 +32,14 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)
 
 
 DEFAULT_RELATION_NAME = "receive-remote-write"
+DEFAULT_CONSUMER_NAME = "send-remote-write"
 RELATION_INTERFACE_NAME = "prometheus_remote_write"
 
 DEFAULT_ALERT_RULES_RELATIVE_PATH = "./src/prometheus_alert_rules"
@@ -732,7 +733,7 @@ class PrometheusRemoteWriteConsumer(Object):
     def __init__(
         self,
         charm: CharmBase,
-        relation_name: str = DEFAULT_RELATION_NAME,
+        relation_name: str = DEFAULT_CONSUMER_NAME,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ provides:
     interface: grafana_dashboard
 
 requires:
-    receive-remote-write:
+    send-remote-write:
         interface: prometheus_remote_write
 
 peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,7 +51,7 @@ class AvalancheCharm(CharmBase):
             "metrics-endpoint",
             jobs=[
                 {
-                    "job_name": self.unit.name,
+                    "job_name": self.model.app.name,
                     "metrics_path": "/metrics",
                     "static_configs": [{"targets": [f"*:{self.port}"]}],
                     "scrape_interval": "15s",  # TODO move to config.yaml

--- a/tests/integration/test_remote_write.py
+++ b/tests/integration/test_remote_write.py
@@ -34,5 +34,5 @@ async def test_charm_successfully_relates_to_prometheus(ops_test):
         await ops_test.model.deploy("ch:prometheus-k8s", application_name="prom", channel="edge")
         await ops_test.model.wait_for_idle(apps=["prom"], status="active")
 
-    await ops_test.model.add_relation("prom:receive-remote-write", "av:receive-remote-write")
+    await ops_test.model.add_relation("prom:receive-remote-write", "av:send-remote-write")
     await ops_test.model.wait_for_idle(apps=["av", "prom"], status="active")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,13 +13,12 @@ class TestCharm(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(AvalancheCharm)
         self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
+        self.harness.begin_with_initial_hooks()
 
-    def _check_services_running(self, app):
+    def test_services_running(self):
         """Check that the supplied service is running and charm is ActiveStatus."""
-        service = self.harness.model.unit.get_container(app).get_service(app)
+        service = self.harness.model.unit.get_container(
+            AvalancheCharm._container_name
+        ).get_service(AvalancheCharm._service_name)
         self.assertTrue(service.is_running())
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
-
-    def test_dummy(self):
-        pass


### PR DESCRIPTION
This PR:
- removes unit number from job name (https://github.com/canonical/prometheus-k8s-operator/issues/244)
- fetch-lib remote-write
- change remote write relation name to default