### PR TITLE
Add badges to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
 # Contributing to avalanche-operator
+![GitHub](https://img.shields.io/github/license/canonical/avalanche-k8s-operator) ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/canonical/avalanche-k8s-operator)
+
 The intended use case of this operator is to be deployed together with
 prometheus-operator.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to avalanche-operator
-![GitHub](https://img.shields.io/github/license/canonical/avalanche-k8s-operator) ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io%2F) ![GitHub](https://img.shields.io/tokei/lines/github/canonical/avalanche-k8s-operator)
+![GitHub](https://img.shields.io/github/license/canonical/avalanche-k8s-operator) ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/tokei/lines/github/canonical/avalanche-k8s-operator)
 ![GitHub](https://img.shields.io/github/issues/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/github/issues-pr/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/github/contributors/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/github/watchers/canonical/avalanche-k8s-operator?style=social)
 
 The intended use case of this operator is to be deployed together with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contributing to avalanche-operator
-![GitHub](https://img.shields.io/github/license/canonical/avalanche-k8s-operator) ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/canonical/avalanche-k8s-operator)
+![GitHub](https://img.shields.io/github/license/canonical/avalanche-k8s-operator) ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io%2F) ![GitHub](https://img.shields.io/tokei/lines/github/canonical/avalanche-k8s-operator)
+![GitHub](https://img.shields.io/github/issues/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/github/issues-pr/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/github/contributors/canonical/avalanche-k8s-operator) ![GitHub](https://img.shields.io/github/watchers/canonical/avalanche-k8s-operator?style=social)
 
 The intended use case of this operator is to be deployed together with
 prometheus-operator.


### PR DESCRIPTION
This PR adds quick overview badges that are interesting in the context of "contributing".

To see a rendered diff, go into "Files changed" and click the rich diff button.

![image](https://user-images.githubusercontent.com/82407168/179044542-5899198b-fa4a-4267-a31d-30afe895b19c.png)
