### PR TITLE
add open port support

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -44,6 +44,7 @@ class AvalancheCharm(CharmBase):
         self._stored.set_default(servers={}, config_hash=None)
 
         self.container = self.unit.get_container(self._container_name)
+        self.unit.open_port(protocol='tcp', port=self._port)
 
         self.metrics_endpoint = MetricsEndpointProvider(
             self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -44,7 +44,7 @@ class AvalancheCharm(CharmBase):
         self._stored.set_default(servers={}, config_hash=None)
 
         self.container = self.unit.get_container(self._container_name)
-        self.unit.open_port(protocol='tcp', port=self._port)
+        self.unit.open_port(protocol="tcp", port=self._port)
 
         self.metrics_endpoint = MetricsEndpointProvider(
             self,


### PR DESCRIPTION
## Issue

Use `ops.Unit.open_port` for the port to show up in Juju status.

Due to a Juju bug, it might not show up there yet; use `juju exec <unit> -- opened-ports` to verify.

## Testing Instructions

```
charmcraft pack
juju deploy ./avalanche-k8s_ubuntu-20.04-amd64.charm avalanche
# Wait for the charm
juju exec --unit avalanche/0 -- opened-ports
```