### PR TITLE
fix: use set_ports instead of open_port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -44,7 +44,7 @@ class AvalancheCharm(CharmBase):
         self._stored.set_default(servers={}, config_hash=None)
 
         self.container = self.unit.get_container(self._container_name)
-        self.unit.open_port(protocol="tcp", port=self._port)
+        self.unit.set_ports(self._port)
 
         self.metrics_endpoint = MetricsEndpointProvider(
             self,


### PR DESCRIPTION
## Issue

`open_port` doesn't close ports; if the port changes on upgrades, the previous one isn't closed.

## Solution

Use `set_ports` instead, as documented [here](https://github.com/canonical/operator/blob/ab239e1156bd206f9825b5be96fbf83121489fee/ops/model.py#L699).