### PR TITLE
Add charmcraft binary-python-packages for Cos-Lib

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,3 +13,7 @@ parts:
   charm:
     build-packages:
     - git
+    charm-binary-python-packages:
+    - cryptography
+    - pydantic
+    - pydantic-core

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,12 +11,13 @@ from charms.prometheus_k8s.v0.prometheus_remote_write import (
     PrometheusRemoteWriteConsumer,
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from kubernetes_service import K8sServicePatch, PatchFailed
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.pebble import Layer
+
+from kubernetes_service import K8sServicePatch, PatchFailed
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,9 +3,10 @@
 
 import unittest
 
-from charm import AvalancheCharm
 from ops.model import ActiveStatus
 from ops.testing import Harness
+
+from charm import AvalancheCharm
 
 
 class TestCharm(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -43,7 +43,7 @@ deps =
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-charm]


### PR DESCRIPTION
## Issue

The following tandem PR:
- https://github.com/canonical/cos-lib/pull/117

requires all charms with the `prometheus_k8s` or `grafana_agent` libs to add `cosl` as a requirement, since these libs depend on `cosl`. These PRs introduce the `cosl` dependency:
- https://github.com/canonical/prometheus-k8s-operator/pull/660
- https://github.com/canonical/grafana-agent-operator/pull/232

Avalanche is missing a rust compiler and will fail to build `pydantic-core` if the following:

``` yaml
charm-binary-python-packages:
    - cryptography
    - pydantic
    - pydantic-core
```
are not added to the charmcraft.yaml
