### PR TITLE
feat: add support for disabling alert rules forwarding

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,12 @@ options:
       Avalanche's CLI default value is 120, but this is too low and quickly overloads the scraper.
       Using 3600000 (10k hours ~ 1 year) in lieu of "inf" (never refresh).
     default: 36000000
+  disable_forwarding_alert_rules:
+    type: boolean
+    description: >
+      Toggle forwarding of alert rules.
+    default: false
+    
     
 
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -178,7 +178,7 @@ configure the following scrape-related settings, which behave as described by th
 - `scrape_timeout`
 - `proxy_url`
 - `relabel_configs`
-- `metrics_relabel_configs`
+- `metric_relabel_configs`
 - `sample_limit`
 - `label_limit`
 - `label_name_length_limit`
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 45
+LIBPATCH = 49
 
 PYDEPS = ["cosl"]
 
@@ -377,7 +377,7 @@ ALLOWED_KEYS = {
     "scrape_timeout",
     "proxy_url",
     "relabel_configs",
-    "metrics_relabel_configs",
+    "metric_relabel_configs",
     "sample_limit",
     "label_limit",
     "label_name_length_limit",
@@ -521,8 +521,8 @@ class PrometheusConfig:
                         # for such a target. Therefore labeling with Juju topology, excluding the
                         # unit name.
                         non_wildcard_static_config["labels"] = {
-                            **non_wildcard_static_config.get("labels", {}),
                             **topology.label_matcher_dict,
+                            **non_wildcard_static_config.get("labels", {}),
                         }
 
                     non_wildcard_static_configs.append(non_wildcard_static_config)
@@ -547,9 +547,9 @@ class PrometheusConfig:
                         if topology:
                             # Add topology labels
                             modified_static_config["labels"] = {
-                                **modified_static_config.get("labels", {}),
                                 **topology.label_matcher_dict,
                                 **{"juju_unit": unit_name},
+                                **modified_static_config.get("labels", {}),
                             }
 
                             # Instance relabeling for topology should be last in order.
@@ -1306,6 +1306,7 @@ class MetricsEndpointProvider(Object):
         relation_name: str = DEFAULT_RELATION_NAME,
         jobs=None,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
+        disable_forwarding_alert_rules: bool = False,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         external_url: str = "",
         lookaside_jobs_callable: Optional[Callable] = None,
@@ -1411,6 +1412,8 @@ class MetricsEndpointProvider(Object):
                 files.  Defaults to "./prometheus_alert_rules",
                 resolved relative to the directory hosting the charm entry file.
                 The alert rules are automatically updated on charm upgrade.
+            disable_forwarding_alert_rules: a boolean flag to toggle forwarding
+                alert rules.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set scrape job data (IP address and others)
             external_url: an optional argument that represents an external url that
@@ -1449,6 +1452,7 @@ class MetricsEndpointProvider(Object):
 
         self._charm = charm
         self._alert_rules_path = alert_rules_path
+        self._disable_alerts = disable_forwarding_alert_rules
         self._relation_name = relation_name
         # sanitize job configurations to the supported subset of parameters
         jobs = [] if jobs is None else jobs
@@ -1530,8 +1534,10 @@ class MetricsEndpointProvider(Object):
             return
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
-        alert_rules.add_path(self._alert_rules_path, recursive=True)
+        if not self._disable_alerts:
+            alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
+        logger.info(f"+++ alert_rules_as_dict: {alert_rules_as_dict}")  # TODO: remove, debug
 
         for relation in self._charm.model.relations[self._relation_name]:
             relation.data[self._charm.app]["scrape_metadata"] = json.dumps(self._scrape_metadata)
@@ -2364,12 +2370,9 @@ class CosTool:
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:
-            path = Path(res).resolve()
-            path.chmod(0o777)
+            path = Path(res).resolve(strict=True)
             return path
-        except NotImplementedError:
-            logger.debug("System lacks support for chmod")
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -22,10 +22,11 @@ import socket
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import yaml
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
+from cosl.rules import AlertRules
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -41,11 +42,13 @@ from ops.model import Relation
 LIBID = "f783823fa75f4b7880eb70f2077ec259"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 6
+
+PYDEPS = ["cosl"]
 
 
 logger = logging.getLogger(__name__)
@@ -169,210 +172,6 @@ def _is_single_alert_rule_format(rules_dict: dict) -> bool:
     return set(rules_dict) >= {"alert", "expr"}
 
 
-class AlertRules:
-    """Utility class for amalgamating prometheus alert rule files and injecting juju topology.
-
-    An `AlertRules` object supports aggregating alert rules from files and directories in both
-    official and single rule file formats using the `add_path()` method. All the alert rules
-    read are annotated with Juju topology labels and amalgamated into a single data structure
-    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
-    easily dumped into JSON format and exchanged over relation data. The dictionary can also
-    be dumped into YAML format and written directly into an alert rules file that is read by
-    Prometheus. Note that multiple `AlertRules` objects must not be written into the same file,
-    since Prometheus allows only a single list of alert rule groups per alert rules file.
-    The official Prometheus format is a YAML file conforming to the Prometheus documentation
-    (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
-    The custom single rule format is a subsection of the official YAML, having a single alert
-    rule, effectively "one alert per file".
-    """
-
-    # This class uses the following terminology for the various parts of a rule file:
-    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
-    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
-    #   of dictionaries that have the "name" and "rules" keys.
-    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
-    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
-    #   the "alert" and "expr" keys.
-    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
-
-    def __init__(self, topology: Optional[JujuTopology] = None):
-        """Build and alert rule object.
-
-        Args:
-            topology: an optional `JujuTopology` instance that is used to annotate all alert rules.
-        """
-        self.topology = topology
-        self.tool = CosTool(None)
-        self.alert_groups = []  # type: List[dict]
-
-    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
-        """Read a rules file from path, injecting juju topology.
-
-        Args:
-            root_path: full path to the root rules folder (used only for generating group name)
-            file_path: full path to a *.rule file.
-
-        Returns:
-            A list of dictionaries representing the rules file, if file is valid (the structure is
-            formed by `yaml.safe_load` of the file); an empty list otherwise.
-        """
-        with file_path.open() as rf:
-            # Load a list of rules from file then add labels and filters
-            try:
-                rule_file = yaml.safe_load(rf)
-
-            except Exception as e:
-                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
-                return []
-
-            if _is_official_alert_rule_format(rule_file):
-                alert_groups = rule_file["groups"]
-            elif _is_single_alert_rule_format(rule_file):
-                # convert to list of alert groups
-                # group name is made up from the file name
-                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
-            else:
-                # invalid/unsupported
-                logger.error("Invalid rules file: %s", file_path.name)
-                return []
-
-            # update rules with additional metadata
-            for alert_group in alert_groups:
-                if not self._is_already_modified(alert_group["name"]):
-                    # update group name with topology and sub-path
-                    alert_group["name"] = self._group_name(
-                        str(root_path),
-                        str(file_path),
-                        alert_group["name"],
-                    )
-
-                # add "juju_" topology labels
-                for alert_rule in alert_group["rules"]:
-                    if "labels" not in alert_rule:
-                        alert_rule["labels"] = {}
-
-                    if self.topology:
-                        # only insert labels that do not already exist
-                        for label, val in self.topology.label_matcher_dict.items():
-                            if label not in alert_rule["labels"]:
-                                alert_rule["labels"][label] = val
-                        # insert juju topology filters into a prometheus alert rule
-                        alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%,?", "", alert_rule["expr"]),
-                            self.topology.label_matcher_dict,
-                        )
-
-            return alert_groups
-
-    def _group_name(self, root_path: str, file_path: str, group_name: str) -> str:
-        """Generate group name from path and topology.
-
-        The group name is made up of the relative path between the root dir_path, the file path,
-        and topology identifier.
-
-        Args:
-            root_path: path to the root rules dir.
-            file_path: path to rule file.
-            group_name: original group name to keep as part of the new augmented group name
-
-        Returns:
-            New group name, augmented by juju topology and relative path.
-        """
-        rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
-        rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
-
-        # Generate group name:
-        #  - name, from juju topology
-        #  - suffix, from the relative path of the rule file;
-        group_name_parts = [self.topology.identifier] if self.topology else []
-        group_name_parts.extend([rel_path, group_name, "alerts"])
-        # filter to remove empty strings
-        return "_".join(filter(None, group_name_parts))
-
-    def _is_already_modified(self, name: str) -> bool:
-        """Detect whether a group name has already been modified with juju topology."""
-        modified_matcher = re.compile(r"^.*?_[\da-f]{8}_.*?alerts$")
-        if modified_matcher.match(name) is not None:
-            return True
-        return False
-
-    @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
-        """Helper function for getting all files in a directory that have a matching suffix.
-
-        Args:
-            dir_path: path to the directory to glob from.
-            suffixes: list of suffixes to include in the glob (items should begin with a period).
-            recursive: a flag indicating whether a glob is recursive (nested) or not.
-
-        Returns:
-            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
-        """
-        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
-        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
-
-    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
-        """Read all rule files in a directory.
-
-        All rules from files for the same directory are loaded into a single
-        group. The generated name of this group includes juju topology.
-        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
-
-        Args:
-            dir_path: directory containing *.rule files (alert rules without groups).
-            recursive: flag indicating whether to scan for rule files recursively.
-
-        Returns:
-            a list of dictionaries representing prometheus alert rule groups, each dictionary
-            representing an alert group (structure determined by `yaml.safe_load`).
-        """
-        alert_groups = []  # type: List[dict]
-
-        # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(
-            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
-        ):
-            alert_groups_from_file = self._from_file(dir_path, file_path)
-            if alert_groups_from_file:
-                logger.debug("Reading alert rule from %s", file_path)
-                alert_groups.extend(alert_groups_from_file)
-
-        return alert_groups
-
-    def add_path(self, path: str, *, recursive: bool = False) -> None:
-        """Add rules from a dir path.
-
-        All rules from files are aggregated into a data structure representing a single rule file.
-        All group names are augmented with juju topology.
-
-        Args:
-            path: either a rules file or a dir of rules files.
-            recursive: whether to read files recursively or not (no impact if `path` is a file).
-
-        Returns:
-            True if path was added else False.
-        """
-        path = Path(path)  # type: Path
-        if path.is_dir():
-            self.alert_groups.extend(self._from_dir(path, recursive))
-        elif path.is_file():
-            self.alert_groups.extend(self._from_file(path.parent, path))
-        else:
-            logger.debug("Alert rules path does not exist: %s", path)
-
-    def as_dict(self) -> dict:
-        """Return standard alert rules file in dict representation.
-
-        Returns:
-            a dictionary containing a single list of alert rule groups.
-            The list of alert rule groups is provided as value of the
-            "groups" dictionary key.
-        """
-        return {"groups": self.alert_groups} if self.alert_groups else {}
-
-
 def _validate_relation_by_interface_and_direction(
     charm: CharmBase,
     relation_name: str,
@@ -412,7 +211,7 @@ def _validate_relation_by_interface_and_direction(
     actual_relation_interface = relation.interface_name
     if actual_relation_interface != expected_relation_interface:
         raise RelationInterfaceMismatchError(
-            relation_name, expected_relation_interface, actual_relation_interface
+            relation_name, expected_relation_interface, actual_relation_interface or "None"
         )
 
     if expected_relation_role == RelationRole.provides:
@@ -503,7 +302,7 @@ class PrometheusRemoteWriteConsumer(Object):
      The `PrometheusRemoteWriteConsumer` object can be instantiated as follows in your charm:
 
      ```
-     from charms.prometheus_k8s.v0.prometheus_remote_write import PrometheusRemoteWriteConsumer
+     from charms.prometheus_k8s.v1.prometheus_remote_write import PrometheusRemoteWriteConsumer
 
      def __init__(self, *args):
          ...
@@ -595,13 +394,14 @@ class PrometheusRemoteWriteConsumer(Object):
      ```
     """
 
-    on = PrometheusRemoteWriteConsumerEvents()
+    on = PrometheusRemoteWriteConsumerEvents()  # pyright: ignore
 
     def __init__(
         self,
         charm: CharmBase,
         relation_name: str = DEFAULT_CONSUMER_NAME,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
+        disable_forwarding_alert_rules: bool = False,
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
 
@@ -610,6 +410,7 @@ class PrometheusRemoteWriteConsumer(Object):
             relation_name: Name of the relation with the `prometheus_remote_write` interface as
                 defined in metadata.yaml.
             alert_rules_path: Path of the directory containing the alert rules.
+            disable_forwarding_alert_rules: Flag to toggle alert rule forwarding.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -638,6 +439,7 @@ class PrometheusRemoteWriteConsumer(Object):
         self._charm = charm
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
+        self._disable_alerts = disable_forwarding_alert_rules
 
         self.topology = JujuTopology.from_charm(charm)
 
@@ -654,12 +456,15 @@ class PrometheusRemoteWriteConsumer(Object):
         self.framework.observe(
             self._charm.on.upgrade_charm, self._push_alerts_to_all_relation_databags
         )
+        self.framework.observe(
+            self._charm.on.config_changed, self._push_alerts_to_all_relation_databags
+        )
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         self.on.endpoints_changed.emit(relation_id=event.relation.id)
 
     def _handle_endpoints_changed(self, event: RelationEvent) -> None:
-        if self._charm.unit.is_leader():
+        if self._charm.unit.is_leader() and event.app is not None:
             ev = json.loads(event.relation.data[event.app].get("event", "{}"))
 
             if ev:
@@ -684,12 +489,13 @@ class PrometheusRemoteWriteConsumer(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules(self.topology)
-        alert_rules.add_path(self._alert_rules_path, recursive=False)
+        alert_rules = AlertRules(query_type="promql", topology=self.topology)
+        if not self._disable_alerts:
+            alert_rules.add_path(self._alert_rules_path)
 
         alert_rules_as_dict = alert_rules.as_dict()
 
-        if alert_rules_as_dict:
+        if alert_rules_as_dict or self._disable_alerts:
             relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:
@@ -762,7 +568,7 @@ class PrometheusRemoteWriteProvider(Object):
     The `PrometheusRemoteWriteProvider` object can be instantiated as follows in your charm:
 
     ```
-    from charms.prometheus_k8s.v0.prometheus_remote_write import PrometheusRemoteWriteProvider
+    from charms.prometheus_k8s.v1.prometheus_remote_write import PrometheusRemoteWriteProvider
 
     def __init__(self, *args):
         ...
@@ -792,15 +598,14 @@ class PrometheusRemoteWriteProvider(Object):
     name to differentiate between "incoming" and "outgoing" remote write interactions is necessary.
     """
 
-    on = PrometheusRemoteWriteProviderEvents()
+    on = PrometheusRemoteWriteProviderEvents()  # pyright: ignore
 
     def __init__(
         self,
         charm: CharmBase,
         relation_name: str = DEFAULT_RELATION_NAME,
-        endpoint_schema: str = "http",
-        endpoint_address: str = "",
-        endpoint_port: Union[str, int] = 9090,
+        *,
+        server_url_func: Callable[[], str] = lambda: f"http://{socket.getfqdn()}:9090",
         endpoint_path: str = "/api/v1/write",
     ):
         """API to manage a provided relation with the `prometheus_remote_write` interface.
@@ -809,14 +614,8 @@ class PrometheusRemoteWriteProvider(Object):
             charm: The charm object that instantiated this class.
             relation_name: Name of the relation with the `prometheus_remote_write` interface as
                 defined in metadata.yaml.
-            endpoint_schema: The URL schema for your remote_write endpoint. Defaults to `http`.
-            endpoint_address: The URL host for your remote_write endpoint as reachable
-                from the client. This might be either the pod IP, or you might want to
-                expose an address routable from outside the Kubernetes cluster, e.g., the
-                host address of an Ingress. If not provided, it defaults to the unit's FQDN.
-            endpoint_port: The URL port for your remote_write endpoint. Defaults to `9090`.
-            endpoint_path: The URL path for your remote_write endpoint.
-                Defaults to `/api/v1/write`.
+            server_url_func: A callable returning the URL for your prometheus server.
+            endpoint_path: The path of the server's remote_write endpoint.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -836,9 +635,7 @@ class PrometheusRemoteWriteProvider(Object):
         self._charm = charm
         self._tool = CosTool(self._charm)
         self._relation_name = relation_name
-        self._endpoint_schema = endpoint_schema
-        self._endpoint_address = endpoint_address
-        self._endpoint_port = int(endpoint_port)
+        self._get_server_url = server_url_func
         self._endpoint_path = endpoint_path
 
         on_relation = self._charm.on[self._relation_name]
@@ -861,7 +658,7 @@ class PrometheusRemoteWriteProvider(Object):
         self.on.consumers_changed.emit()
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
-        """Flag Providers that data has changed so they can re-read alerts."""
+        """Flag Providers that data has changed, so they can re-read alerts."""
         self.on.alert_rules_changed.emit(event.relation.id)
 
     def update_endpoint(self, relation: Optional[Relation] = None) -> None:
@@ -889,19 +686,9 @@ class PrometheusRemoteWriteProvider(Object):
         Args:
             relation: The relation whose data to update.
         """
-        address = self._endpoint_address or socket.getfqdn()
-
-        path = self._endpoint_path or ""
-        if path and not path.startswith("/"):
-            path = "/{}".format(path)
-
-        endpoint_url = "{}://{}:{}{}".format(
-            self._endpoint_schema, address, str(self._endpoint_port), path
-        )
-
         relation.data[self._charm.unit]["remote_write"] = json.dumps(
             {
-                "url": endpoint_url,
+                "url": self._get_server_url().rstrip("/") + "/" + self._endpoint_path.strip("/"),
             }
         )
 
@@ -969,6 +756,7 @@ class PrometheusRemoteWriteProvider(Object):
 
             _, errmsg = self._tool.validate_alert_rules(alert_rules)
             if errmsg:
+                logger.error(f"Invalid alert rule file: {errmsg}")
                 if self._charm.unit.is_leader():
                     data = json.loads(relation.data[self._charm.app].get("event", "{}"))
                     data["errors"] = errmsg
@@ -1058,7 +846,7 @@ class PrometheusRemoteWriteProvider(Object):
                         # Inject topology and put it back in the list
                         rule["expr"] = self._tool.inject_label_matchers(
                             re.sub(r"%%juju_topology%%,?", "", rule["expr"]),
-                            topology.label_matcher_dict,
+                            topology.alert_expression_dict,
                         )
                     except KeyError:
                         # Some required JujuTopology key is missing. Just move on.
@@ -1167,12 +955,9 @@ class CosTool:
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:
-            path = Path(res).resolve()
-            path.chmod(0o777)
+            path = Path(res).resolve(strict=True)
             return path
-        except NotImplementedError:
-            logger.debug("System lacks support for chmod")
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 


### PR DESCRIPTION
## Issue
Related to https://github.com/canonical/prometheus-k8s-operator/pull/673


## Solution
Add a config `disable_forwarding_alert_rules` config option and pass it to the Prometheus libraries.


## Context
Avalanche is a great charm for a first implementation of this feature, because it can relate to Prometheus over both `prometheus_scrape` and `prometheus_remote_write`, without the extra complications of *cos-proxy* or *grafana-agent*. This allows to better test whether the library is working or not.


## Testing Instructions
Deploy `avalanche` from this PR + `prometheus`, relate them, and try to toggle the alert rules with `juju config`. Observe the alert rules appearing and disappearing both in relation data and in the Prometheus UI.

