### PR TITLE
feat: bump version to v0.7.0 and update image source

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -34,7 +34,7 @@ resources:
   avalanche-image:
     type: oci-image
     description: OCI image for avalanche
-    upstream-source: quay.io/freshtracks.io/avalanche
+    upstream-source: quay.io/prometheuscommunity/avalanche:v0.7.0
 
 provides:
   metrics-endpoint:

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,7 +182,7 @@ class AvalancheCharm(CharmBase):
             return " ".join(
                 [
                     "/bin/avalanche",
-                    f"--metric-count={self.config['metric_count']}",
+                    f"--gauge-metric-count={self.config['metric_count']}",
                     f"--label-count={self.config['label_count']}",
                     f"--series-count={self.config['series_count']}",
                     f"--metricname-length={self.config['metricname_length']}",


### PR DESCRIPTION
We're using an outdated image; this update is needed before we create a `0.7` track for the charm.

## Changes

- Update `upstream-source` from `quay.io/freshtracks.io/avalanche` to `quay.io/prometheuscommunity/avalanche:v0.7.0`
- Fix breaking CLI change: replace `--metric-count` with `--gauge-metric-count`

## Breaking change in avalanche v0.7.0

The `--metric-count` flag was [deprecated in v0.6.0](https://github.com/prometheus-community/avalanche/blob/main/CHANGELOG.md#060--2024-10-14) and [removed in v0.7.0](https://github.com/prometheus-community/avalanche/blob/main/CHANGELOG.md#070--2025-01-14). The replacement is `--gauge-metric-count`. Without this fix, the avalanche binary rejects the unknown flag and the Pebble service crashes on startup, causing the `config-changed` hook to fail in a loop.

The charm config option (`metric_count`) is unchanged — only the CLI flag passed to the avalanche binary is updated.